### PR TITLE
fix 'openocd -f' command typo in VERIFY.md

### DIFF
--- a/src/setup/VERIFY.md
+++ b/src/setup/VERIFY.md
@@ -47,7 +47,7 @@ Next, run this command:
 
 ``` shell
 $ # *nix
-$ openocd-f interface/cmsis-dap.cfg -f target/nrf51.cfg
+$ openocd -f interface/cmsis-dap.cfg -f target/nrf51.cfg
 
 $ # Windows
 $ # NOTE cygwin users have reported problems with the -s flag. If you run into


### PR DESCRIPTION
Small typo found in the documentation (VERIFY.md) 