### PR TITLE
fix: macos installation doesn't require brew cask anymore

### DIFF
--- a/src/setup/MACOS.md
+++ b/src/setup/MACOS.md
@@ -7,12 +7,8 @@ All the tools can be install using [Homebrew]:
 [Homebrew]: http://brew.sh/
 
 ``` shell
-$ brew cask install gcc-arm-embedded
-$ brew install minicom openocd
+$ brew install armmbed/formulae/arm-none-eabi-gcc minicom openocd
 ```
-
-If the `brew cask` command doesn't work (`Error: Unknown command: cask`), then run `brew tap
-Caskroom/tap` first and try again.
 
 That's all! Go to the [next section].
 


### PR DESCRIPTION
As mentioned in #9 it looks like `brew cask` is not necessary anymore because the formula doesn't exist. I updated the documentation to install the correct formula.