### PR TITLE
fix: microbit display example

### DIFF
--- a/src/microbit/examples/display_blocking.rs
+++ b/src/microbit/examples/display_blocking.rs
@@ -23,25 +23,25 @@ fn main() -> ! {
         let mut delay = Delay::new(p.TIMER0);
 
         // Configure display pins
-        let row1 = gpio.pin13.into_push_pull_output().downgrade();
-        let row2 = gpio.pin14.into_push_pull_output().downgrade();
-        let row3 = gpio.pin15.into_push_pull_output().downgrade();
-        let col1 = gpio.pin4.into_push_pull_output().downgrade();
-        let col2 = gpio.pin5.into_push_pull_output().downgrade();
-        let col3 = gpio.pin6.into_push_pull_output().downgrade();
-        let col4 = gpio.pin7.into_push_pull_output().downgrade();
-        let col5 = gpio.pin8.into_push_pull_output().downgrade();
-        let col6 = gpio.pin9.into_push_pull_output().downgrade();
-        let col7 = gpio.pin10.into_push_pull_output().downgrade();
-        let col8 = gpio.pin11.into_push_pull_output().downgrade();
-        let col9 = gpio.pin12.into_push_pull_output().downgrade();
+        let row1 = gpio.pin13.into_push_pull_output();
+        let row2 = gpio.pin14.into_push_pull_output();
+        let row3 = gpio.pin15.into_push_pull_output();
+        let col1 = gpio.pin4.into_push_pull_output();
+        let col2 = gpio.pin5.into_push_pull_output();
+        let col3 = gpio.pin6.into_push_pull_output();
+        let col4 = gpio.pin7.into_push_pull_output();
+        let col5 = gpio.pin8.into_push_pull_output();
+        let col6 = gpio.pin9.into_push_pull_output();
+        let col7 = gpio.pin10.into_push_pull_output();
+        let col8 = gpio.pin11.into_push_pull_output();
+        let col9 = gpio.pin12.into_push_pull_output();
 
         // Configure RX and TX pins accordingly
         let tx = gpio.pin24.into_push_pull_output().downgrade();
         let rx = gpio.pin25.into_floating_input().downgrade();
 
         let mut leds = led::Display::new(
-            row1, row2, row3, col1, col2, col3, col4, col5, col6, col7, col8, col9,
+            col1, col2, col3, col4, col5, col6, col7, col8, col9, row1, row2, row3,
         );
 
         let (mut tx, _) = serial::Serial::uart0(p.UART0, tx, rx, BAUD115200).split();


### PR DESCRIPTION
It looks like the `led::Display::new` function signature has changed. I fixed the params order and remove the unnecessary `downgrade` calls.