### PR TITLE
Use gdb-multiarch instead of gdb-arm-none-eabi

### DIFF
--- a/src/getting-started/02.00.FLASH.md
+++ b/src/getting-started/02.00.FLASH.md
@@ -71,6 +71,7 @@ available.
 I mentioned that OpenOCD provides a GDB server so let's connect to that right now:
 
 ``` console
+# On Ubuntu use `gdb-mutliarch -q target/thumbv6m-none-eabi/debug/rustled`
 $ arm-none-eabi-gdb -q target/thumbv6m-none-eabi/debug/rustled
 Reading symbols from target/thumbv6m-none-eabi/debug/rustled...done.
 (gdb)

--- a/src/setup/LINUX.md
+++ b/src/setup/LINUX.md
@@ -9,7 +9,7 @@ Here are the installation commands for a few Linux distributions.
 ``` shell
 $ sudo apt-get install \
   gcc-arm-none-eabi \
-  gdb-arm-none-eabi \
+  gdb-multiarch \
   minicom \
   openocd
 ```


### PR DESCRIPTION
https://askubuntu.com/questions/1031103/how-to-install-gdb-arm-none-eabi-on-ubuntu-18-04#comment1682182_1032469