### PR TITLE
break main instead of break rustled::main

### DIFF
--- a/src/getting-started/02.00.FLASH.md
+++ b/src/getting-started/02.00.FLASH.md
@@ -157,7 +157,7 @@ set print asm-demangle on
 # Load your program, breaks at entry
 load
 # (optional) Add breakpoint at function
-break rustled::main
+break main
 # Continue with execution
 continue
 ```


### PR DESCRIPTION
It didn't work for me with `rustled::`