### PR TITLE
use #[entry] instead of entry!

### DIFF
--- a/src/getting-started/03.00.DEBUG.md
+++ b/src/getting-started/03.00.DEBUG.md
@@ -6,7 +6,7 @@ Before we start, let's add some code to debug:
 
 ``` rust
 // -- snip --
-entry!(main);
+#[entry]
 fn main() -> ! {
     let _y;
     let x = 42;


### PR DESCRIPTION
>[breaking-change] the entry!, pre_init! and exception! macros have been replaced with attributes: #[entry], #[pre_init] and #[exception], respectively.

https://github.com/rust-embedded/cortex-m-rt/blob/9a4a26039808ca2089ed82c802878acfbc22070c/CHANGELOG.md#v060---2018-09-06