### PR TITLE
Bumped micro-rust dependency to 0.8

### DIFF
--- a/src/getting-started/Cargo.toml
+++ b/src/getting-started/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.2.0"
 
 [dependencies]
 panic-halt = "~0.2"
-microbit="~0.7"
+microbit="~0.8"
 cortex-m-rt="~0.6"


### PR DESCRIPTION
Had some issues with the new digital traits, when I bumped the dependency to 0.8 it worked. 