### PR TITLE
Update MacOS Install

### DIFF
--- a/src/setup/MACOS.md
+++ b/src/setup/MACOS.md
@@ -5,7 +5,7 @@ All the tools can be install using [Homebrew]:
 [Homebrew]: http://brew.sh/
 
 ``` shell
-$ brew cask install https://raw.githubusercontent.com/Homebrew/homebrew-cask/b88346667547cc85f8f2cacb3dfe7b754c8afc8a/Casks/gcc-arm-embedded.rb
+$ brew install --cask gcc-arm-embedded
 $ brew install minicom openocd
 ```
 


### PR DESCRIPTION
The `gcc-arm-embedded` cask was added back into homebrew cask (Homebrew/homebrew-cask#96856), and `brew cask` has been deprecated. I've updated the docs with the correct installation instructions.